### PR TITLE
Support list markers and indentation, fixes #2

### DIFF
--- a/examples/minimad-cli.rs
+++ b/examples/minimad-cli.rs
@@ -1,0 +1,51 @@
+//! A simple CLI tool for testing Minimad parsing.
+//!
+//! Run with: cargo run --example minimad-cli [markdown content]
+
+use minimad::{CompositeStyle, Line, Options, parse_text};
+use std::{env, fs};
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    let md = if args.len() > 1 {
+        fs::read_to_string(&args[1]).expect("Could not read file")
+    } else {
+        "- Test\n  - Nested \n  - Still nested \n    - One level deeper \n  - Again Nested "
+            .to_string()
+    };
+    let text = parse_text(&md, Options::default());
+
+    for (i, line) in text.lines.iter().enumerate() {
+        match line {
+            Line::Normal(composite) => {
+                let style_name = match &composite.style {
+                    CompositeStyle::Paragraph => "Paragraph",
+                    CompositeStyle::Header(_n) => "Header",
+                    CompositeStyle::ListItem(_d) => "ListItem",
+                    CompositeStyle::Code => "Code",
+                    CompositeStyle::Quote => "Quote",
+                };
+                let depth = match &composite.style {
+                    CompositeStyle::ListItem(d) => *d,
+                    _ => 0,
+                };
+                let content: String = composite.compounds.iter().map(|c| c.src).collect();
+                println!("Line {}: [{}] depth={} '{}'", i, style_name, depth, content);
+            }
+            Line::TableRow(row) => {
+                println!("Line {}: TableRow with {} cells", i, row.cells.len());
+            }
+            Line::TableRule(rule) => {
+                println!("Line {}: TableRule {:?}", i, rule);
+            }
+            Line::CodeFence(composite) => {
+                let content: String = composite.compounds.iter().map(|c| c.src).collect();
+                println!("Line {}: CodeFence '{}'", i, content);
+            }
+            Line::HorizontalRule => {
+                println!("Line {}: HorizontalRule", i);
+            }
+        }
+    }
+}

--- a/src/markdown/compound.rs
+++ b/src/markdown/compound.rs
@@ -1,7 +1,4 @@
-use std::fmt::{
-    self,
-    Write,
-};
+use std::fmt::{self, Write};
 
 /// a Compound is a part of a line with a consistent styling.
 /// It can be part of word, several words, some inline code, or even the whole line.
@@ -165,7 +162,8 @@ impl<'s> Compound<'s> {
         strikeout: bool,
     ) -> Compound<'s> {
         Compound {
-            src: &src[start..end],
+            // Ensure indices are within bounds
+            src: src.get(start..end).unwrap_or(""),
             italic,
             bold,
             code,

--- a/src/parser/line_parser.rs
+++ b/src/parser/line_parser.rs
@@ -48,14 +48,16 @@ impl<'s> LineParser<'s> {
                 self.strikeout,
             ));
         }
-        self.idx = end + tag_length;
+        self.idx = (end + tag_length).min(self.src.len());
     }
+
     fn code_block_compound_from_idx(
         &self,
         idx: usize,
     ) -> Compound<'s> {
         Compound::new(self.src, idx, self.src.len(), false, false, false, false)
     }
+
     fn parse_compounds(
         &mut self,
         stop_on_pipe: bool,
@@ -237,7 +239,14 @@ impl<'s> LineParser<'s> {
     pub fn line(mut self) -> Line<'s> {
         self.parse_line()
     }
-    pub(crate) fn parse_line(&mut self) -> Line<'s> {
+
+    /// Parse a line with context about list nesting
+    pub(crate) fn parse_line_with_context(
+        &mut self,
+        list_marker_info: Option<&crate::parser::text_parser::ListMarkerInfo>,
+        calculated_depth: u8,
+    ) -> Line<'s> {
+        // First check for code fences and tables which don't depend on context
         if self.src.starts_with('|') {
             let tr = TableRow {
                 cells: self.parse_cells(),
@@ -247,11 +256,104 @@ impl<'s> LineParser<'s> {
                 None => Line::TableRow(tr),
             };
         }
+
+        // Check for quote lines
+        if self.src.starts_with("> ") || self.src == ">" {
+            if self.src.starts_with("> ") {
+                self.idx = 2;
+            }
+            return Line::new_quote(self.parse_compounds(false));
+        }
+
+        // Check for code fences
+        if self.src.starts_with("```") {
+            self.idx = 3;
+            return Line::new_code_fence(self.parse_compounds(false));
+        }
+
+        // Check for list markers (prioritize when we have context)
+        if let Some(info) = list_marker_info {
+            // Use the pre-calculated depth from the text parser
+            let depth = calculated_depth;
+
+            // Set index based on marker position using byte offset
+            let marker_and_space = info.marker_width as usize;
+            self.idx = (info.byte_offset as usize + marker_and_space).min(self.src.len());
+
+            return Line::new_list_item(depth, self.parse_compounds(false));
+        }
+
+        // Check for code blocks (4 spaces or tab) - only if no list marker was found
         if self.src.starts_with("    ") {
             return Line::new_code(self.code_block_compound_from_idx(4));
         }
+
+        // Check for tab-indented code block (not followed by list marker)
         if self.src.starts_with('\t') {
+            let rest = &self.src[1..];
+            if !rest.starts_with("- ") && !rest.starts_with("* ") && !rest.starts_with("+ ") {
+                return Line::new_code(self.code_block_compound_from_idx(1));
+            }
+        }
+
+        // Check for tab-indented lists (CommonMark: tab at start followed by list marker)
+        if self.src.starts_with("\t- ") {
+            self.idx = 3;
+            return Line::new_list_item(1, self.parse_compounds(false));
+        }
+        if self.src.starts_with("\t* ") {
+            self.idx = 3;
+            return Line::new_list_item(1, self.parse_compounds(false));
+        }
+        if self.src.starts_with("\t+ ") {
+            self.idx = 3;
+            return Line::new_list_item(1, self.parse_compounds(false));
+        }
+
+        // Fall back to the original parse_line for other cases
+        self.parse_line_fallback()
+    }
+
+    /// Fallback method that contains the original hardcoded space-counting logic
+    fn parse_line_fallback(&mut self) -> Line<'s> {
+        // Reset state
+        self.idx = 0;
+
+        // Tables first
+        if self.src.starts_with('|') {
+            let tr = TableRow {
+                cells: self.parse_cells(),
+            };
+            return match tr.as_table_alignments() {
+                Some(aligns) => Line::TableRule(aligns),
+                None => Line::TableRow(tr),
+            };
+        }
+
+        // Code block: 4 spaces
+        if self.src.starts_with("    ") {
+            return Line::new_code(self.code_block_compound_from_idx(4));
+        }
+        // Code block: tab not followed by list marker
+        if self.src.starts_with('\t')
+            && !self.src[1..].starts_with("- ")
+            && !self.src[1..].starts_with("* ")
+            && !self.src[1..].starts_with("+ ")
+        {
             return Line::new_code(self.code_block_compound_from_idx(1));
+        }
+        // Support tab-indented lists (CommonMark: tab at start followed by list marker)
+        if self.src.starts_with("\t- ") {
+            self.idx = 3;
+            return Line::new_list_item(1, self.parse_compounds(false));
+        }
+        if self.src.starts_with("\t* ") {
+            self.idx = 3;
+            return Line::new_list_item(1, self.parse_compounds(false));
+        }
+        if self.src.starts_with("\t+ ") {
+            self.idx = 3;
+            return Line::new_list_item(1, self.parse_compounds(false));
         }
         if self.src.starts_with("* ") {
             self.idx = 2;
@@ -266,6 +368,39 @@ impl<'s> LineParser<'s> {
             return Line::new_list_item(2, self.parse_compounds(false));
         }
         if self.src.starts_with("   * ") {
+            self.idx = 5;
+            return Line::new_list_item(3, self.parse_compounds(false));
+        }
+        // Support dash (-) and plus (+) list markers
+        if self.src.starts_with("- ") {
+            self.idx = 2;
+            return Line::new_list_item(0, self.parse_compounds(false));
+        }
+        if self.src.starts_with(" - ") {
+            self.idx = 3;
+            return Line::new_list_item(1, self.parse_compounds(false));
+        }
+        if self.src.starts_with("  - ") {
+            self.idx = 4;
+            return Line::new_list_item(2, self.parse_compounds(false));
+        }
+        if self.src.starts_with("   - ") {
+            self.idx = 5;
+            return Line::new_list_item(3, self.parse_compounds(false));
+        }
+        if self.src.starts_with("+") {
+            self.idx = 2;
+            return Line::new_list_item(0, self.parse_compounds(false));
+        }
+        if self.src.starts_with(" + ") {
+            self.idx = 3;
+            return Line::new_list_item(1, self.parse_compounds(false));
+        }
+        if self.src.starts_with("  + ") {
+            self.idx = 4;
+            return Line::new_list_item(2, self.parse_compounds(false));
+        }
+        if self.src.starts_with("   + ") {
             self.idx = 5;
             return Line::new_list_item(3, self.parse_compounds(false));
         }
@@ -291,6 +426,11 @@ impl<'s> LineParser<'s> {
         } else {
             Line::new_paragraph(compounds)
         }
+    }
+
+    /// Original parse_line method - delegates to fallback
+    pub(crate) fn parse_line(&mut self) -> Line<'s> {
+        self.parse_line_fallback()
     }
 }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -82,3 +82,167 @@ fn test_inline_code_continuation() {
         },
     );
 }
+
+// CommonMark list nesting tests
+#[test]
+fn commonmark_basic_list_nesting() {
+    use crate::*;
+    let md = r#"* level 0
+  * level 1
+   * level 2"#;
+    let text = parse_text(md, Options::default());
+    assert_eq!(text.lines.len(), 3);
+
+    if let Line::Normal(composite) = &text.lines[0] {
+        assert_eq!(composite.style, CompositeStyle::ListItem(0));
+    } else {
+        panic!("First line should be a list item");
+    }
+
+    if let Line::Normal(composite) = &text.lines[1] {
+        assert_eq!(composite.style, CompositeStyle::ListItem(1));
+    } else {
+        panic!("Second line should be a list item");
+    }
+
+    if let Line::Normal(composite) = &text.lines[2] {
+        assert_eq!(composite.style, CompositeStyle::ListItem(1));
+    } else {
+        panic!("Third line should be a list item");
+    }
+}
+
+#[test]
+fn commonmark_list_nesting_with_different_indents() {
+    use crate::*;
+    let md = r#"* level 0
+ * not nested (1 space)
+  * nested (2 spaces)
+   * nested (3 spaces)"#;
+    let text = parse_text(md, Options::default());
+    assert_eq!(text.lines.len(), 4);
+
+    if let Line::Normal(composite) = &text.lines[1] {
+        assert_eq!(
+            composite.style,
+            CompositeStyle::ListItem(0),
+            "Line 1 with 1 space should NOT be nested"
+        );
+    }
+
+    if let Line::Normal(composite) = &text.lines[2] {
+        assert_eq!(
+            composite.style,
+            CompositeStyle::ListItem(1),
+            "Line 2 with 2 spaces should be nested"
+        );
+    }
+
+    if let Line::Normal(composite) = &text.lines[3] {
+        assert_eq!(
+            composite.style,
+            CompositeStyle::ListItem(1),
+            "Line 3 with 3 spaces should be nested"
+        );
+    }
+}
+
+#[test]
+fn commonmark_list_nesting_with_4_spaces() {
+    use crate::*;
+    // 4 spaces with list marker creates nested list item, not code block
+    // This allows deeper nesting beyond 3 levels
+    let md = r#"* level 0
+    * level 1"#;
+    let text = parse_text(md, Options::default());
+    assert_eq!(text.lines.len(), 2);
+
+    if let Line::Normal(composite) = &text.lines[1] {
+        assert_eq!(composite.style, CompositeStyle::ListItem(1));
+    } else {
+        panic!("Second line should be nested list item");
+    }
+}
+
+#[test]
+fn commonmark_ordered_list_nesting() {
+    use crate::*;
+    let md = r#"1. level 0
+   2. level 1"#;
+    let text = parse_text(md, Options::default());
+    assert_eq!(text.lines.len(), 2);
+
+    if let Line::Normal(composite) = &text.lines[1] {
+        assert_eq!(composite.style, CompositeStyle::ListItem(1));
+    }
+}
+
+#[test]
+fn commonmark_list_same_level() {
+    use crate::*;
+    let md = r#"* item 1
+* item 2
+* item 3"#;
+    let text = parse_text(md, Options::default());
+    assert_eq!(text.lines.len(), 3);
+
+    for (i, line) in text.lines.iter().enumerate() {
+        if let Line::Normal(composite) = line {
+            assert_eq!(
+                composite.style,
+                CompositeStyle::ListItem(0),
+                "Line {} should be at depth 0",
+                i
+            );
+        } else {
+            panic!("Line {} should be a list item", i);
+        }
+    }
+}
+
+#[test]
+fn commonmark_list_mixed_markers() {
+    use crate::*;
+    let md = r#"- parent
+  * child"#;
+    let text = parse_text(md, Options::default());
+    assert_eq!(text.lines.len(), 2);
+
+    if let Line::Normal(composite) = &text.lines[1] {
+        assert_eq!(composite.style, CompositeStyle::ListItem(1));
+    }
+}
+
+#[test]
+fn commonmark_tab_indented_list() {
+    use crate::*;
+    let md = "- parent\n\t- child\n- sibling";
+    let text = parse_text(md, Options::default());
+    assert_eq!(text.lines.len(), 3);
+
+    if let Line::Normal(composite) = &text.lines[1] {
+        assert_eq!(
+            composite.style,
+            CompositeStyle::ListItem(1),
+            "Tab-indented line should be nested"
+        );
+    }
+}
+
+#[test]
+fn tab_indented_children_after_shifted_top_level_item() {
+    use crate::*;
+    let md = "\t- shifted top level\n- parent\n\t- child";
+    let text = parse_text(md, Options::default());
+    assert_eq!(text.lines.len(), 3);
+
+    if let Line::Normal(composite) = &text.lines[2] {
+        assert_eq!(
+            composite.style,
+            CompositeStyle::ListItem(1),
+            "Tab-indented child should nest under the latest parent context"
+        );
+    } else {
+        panic!("Third line should be a nested list item");
+    }
+}

--- a/src/parser/options.rs
+++ b/src/parser/options.rs
@@ -3,7 +3,7 @@
 pub struct Options {
     /// Remove one or several superfluous levels of indentations
     ///
-    /// This is useful when your text is too deeply intended, for
+    /// This is useful when your text is too deeply indented, for
     /// example because it's defined in a raw literal:
     ///
     /// ```

--- a/src/parser/text_parser.rs
+++ b/src/parser/text_parser.rs
@@ -12,6 +12,129 @@ pub fn parse(
     }
 }
 
+/// State for tracking list containers during parsing
+#[derive(Debug, Clone)]
+struct ParseState {
+    /// Stack of active list contexts (most recent first)
+    list_stack: Vec<ListContext>,
+    /// Are we currently in a code fence?
+    between_fences: bool,
+}
+
+/// Context for an active list container
+#[derive(Debug, Clone)]
+pub struct ListContext {
+    /// Column position (0-indexed) where the list marker starts
+    pub marker_column: u32,
+    /// Width of the list marker (e.g., 2 for "- ", 3 for "10. ")
+    pub marker_width: u32,
+    /// Current depth of this list
+    pub depth: u8,
+}
+
+impl ParseState {
+    fn new() -> Self {
+        ParseState {
+            list_stack: Vec::new(),
+            between_fences: false,
+        }
+    }
+
+    /// Get the current list context if any
+    fn current_list(&self) -> Option<&ListContext> {
+        self.list_stack.last()
+    }
+}
+
+/// Information about a list marker found at the start of a line
+#[derive(Debug, Clone)]
+pub struct ListMarkerInfo {
+    /// Column where the marker starts (0-indexed)
+    pub column: u32,
+    /// Byte offset where the marker starts (for proper string slicing)
+    pub byte_offset: u32,
+    /// Width of the marker including following space
+    pub marker_width: u32,
+}
+
+/// Find list marker at the start of a line
+/// Returns None if no list marker found
+fn find_list_marker(line: &str) -> Option<ListMarkerInfo> {
+    // Calculate the visual column, treating tabs as 4 spaces
+    let visual_column = calculate_visual_column(line);
+    // Find the byte offset of the first non-whitespace character
+    let byte_offset = line.len() - line.trim_start().len();
+    let trimmed = line.trim_start();
+
+    if trimmed.starts_with("-") || trimmed.starts_with("*") || trimmed.starts_with("+") {
+        // Bullet list marker
+        let marker_len = 1;
+        let after_marker = &trimmed[marker_len..];
+
+        // Check if followed by space, tab, or end of line
+        if after_marker.starts_with(' ')
+            || after_marker.starts_with('\t')
+            || after_marker.is_empty()
+        {
+            Some(ListMarkerInfo {
+                column: visual_column,
+                byte_offset: byte_offset as u32,
+                marker_width: marker_len as u32 + 1, // marker + space
+            })
+        } else {
+            None
+        }
+    } else if let Some(digit_start) = trimmed.find(|c: char| c.is_ascii_digit()) {
+        if digit_start == 0 {
+            // Starts with digit - could be ordered list
+            let digits_end = trimmed.chars().take_while(|c| c.is_ascii_digit()).count();
+
+            if digits_end < trimmed.len() {
+                let next_char = trimmed.chars().nth(digits_end).unwrap();
+                if next_char == '.' || next_char == ')' {
+                    let after_marker = &trimmed[digits_end + 1..];
+                    // Check if followed by space, tab, or end of line
+                    if after_marker.starts_with(' ')
+                        || after_marker.starts_with('\t')
+                        || after_marker.is_empty()
+                    {
+                        let marker_width = digits_end as u32 + 2; // digits + marker + space
+                        Some(ListMarkerInfo {
+                            column: visual_column,
+                            byte_offset: byte_offset as u32,
+                            marker_width,
+                        })
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+/// Calculate the visual column position of the first non-whitespace character
+/// Tabs are treated as 4 spaces each
+fn calculate_visual_column(line: &str) -> u32 {
+    let mut column = 0u32;
+    for c in line.chars() {
+        match c {
+            ' ' => column += 1,
+            '\t' => column += 4,
+            _ => break,
+        }
+    }
+    column
+}
+
 /// Parse lines
 pub(crate) fn parse_lines<'s, I>(
     md_lines: I,
@@ -21,14 +144,49 @@ where
     I: Iterator<Item = &'s str>,
 {
     let mut lines = Vec::new();
-    let mut between_fences = false;
+    let mut state = ParseState::new();
     let mut continue_code = false;
     let mut continue_italic = false;
     let mut continue_bold = false;
     let mut continue_strikeout = false;
+
     for md_line in md_lines {
         let mut line_parser = parser::LineParser::from(md_line);
-        let line = if between_fences {
+
+        // Check if line starts with list marker and get its info
+        let list_marker_info = find_list_marker(md_line);
+
+        // Calculate depth for this list item based on parent context
+        let calculated_depth = if let Some(info) = &list_marker_info {
+            // Search through the stack to find the right parent
+            let mut parent_depth = 0u8;
+            let mut found_parent = false;
+            for list_ctx in state.list_stack.iter().rev() {
+                // Check if this marker is nested under this list
+                if info.column >= list_ctx.marker_column + list_ctx.marker_width {
+                    // Nested under this list
+                    parent_depth = list_ctx.depth + 1;
+                    found_parent = true;
+                    break;
+                } else if info.column == list_ctx.marker_column {
+                    // Same column, same list
+                    parent_depth = list_ctx.depth;
+                    found_parent = true;
+                    break;
+                }
+                // Continue searching up the stack
+            }
+            if found_parent {
+                parent_depth
+            } else {
+                // No parent found, top-level
+                0
+            }
+        } else {
+            0
+        };
+
+        let line = if state.between_fences {
             continue_code = false;
             continue_italic = false;
             continue_bold = false;
@@ -47,18 +205,63 @@ where
             if continue_strikeout {
                 line_parser.strikeout = true;
             }
-            let line = line_parser.parse_line();
+
+            // Parse the line with context
+            let line =
+                line_parser.parse_line_with_context(list_marker_info.as_ref(), calculated_depth);
+
             continue_code = options.continue_inline_code && line_parser.code;
             continue_italic = options.continue_italic && line_parser.italic;
             continue_bold = options.continue_bold && line_parser.bold;
             continue_strikeout = options.continue_strikeout && line_parser.strikeout;
             line
         };
-        match line {
+
+        // Update state based on the parsed line
+        match &line {
             Line::CodeFence(..) => {
-                between_fences = !between_fences;
+                state.between_fences = !state.between_fences;
                 if options.keep_code_fences {
                     lines.push(line);
+                }
+                // Close any open lists when entering/leaving code fence
+                state.list_stack.clear();
+            }
+            Line::Normal(composite) => {
+                match &composite.style {
+                    CompositeStyle::ListItem(depth) => {
+                        // Handle list items
+                        if let Some(info) = list_marker_info {
+                            // This line starts a new list item
+                            let marker_column = info.column;
+                            let marker_width = info.marker_width;
+
+                            // Keep ancestor contexts and previous same-depth contexts.
+                            // Same-depth history is needed because markdown allows slight marker shifts
+                            // while still belonging to the same logical list level.
+                            while let Some(top_list) = state.current_list() {
+                                if top_list.depth <= *depth {
+                                    break;
+                                }
+                                state.list_stack.pop();
+                            }
+
+                            // Track the current item context.
+                            state.list_stack.push(ListContext {
+                                marker_column,
+                                marker_width,
+                                depth: *depth,
+                            });
+                        }
+                        lines.push(line);
+                    }
+                    _ => {
+                        if md_line.trim().is_empty() {
+                            // Blank line closes active list contexts
+                            state.list_stack.clear();
+                        }
+                        lines.push(line);
+                    }
                 }
             }
             _ => {


### PR DESCRIPTION
I tried to make it according to CommonMark standards. 

If you wonder about the additional `.max(src.len())`: I had some panics when using this and this fixed it. I could not reproduce them now unfortunately. 