### PR TITLE
Support -, + and ordered list markers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minimad"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["dystroy <denys.seguret@gmail.com>"]
 repository = "https://github.com/Canop/minimad"
 description = "light Markdown parser"

--- a/src/markdown/composite.rs
+++ b/src/markdown/composite.rs
@@ -6,8 +6,9 @@ use crate::*;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum CompositeStyle {
     Paragraph,
-    Header(u8),   // never 0, and <= MAX_HEADER_DEPTH
-    ListItem(u8), // can't be built > 3 by parsing
+    Header(u8),          // never 0, and <= MAX_HEADER_DEPTH
+    ListItem(u8),        // can't be built > 3 by parsing: *, -, +
+    OrderedListItem(u8), // can't be built > 3 by parsing: 1., 1)
     Code,
     Quote,
 }
@@ -58,7 +59,10 @@ impl<'a> Composite<'a> {
         matches!(self.style, CompositeStyle::Code)
     }
     pub fn is_list_item(&self) -> bool {
-        matches!(self.style, CompositeStyle::ListItem { .. })
+        matches!(
+            self.style,
+            CompositeStyle::ListItem(_) | CompositeStyle::OrderedListItem(_)
+        )
     }
     pub fn is_quote(&self) -> bool {
         matches!(self.style, CompositeStyle::Quote)

--- a/src/markdown/composite.rs
+++ b/src/markdown/composite.rs
@@ -6,9 +6,13 @@ use crate::*;
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum CompositeStyle {
     Paragraph,
-    Header(u8),          // never 0, and <= MAX_HEADER_DEPTH
-    ListItem(u8),        // can't be built > 3 by parsing: *, -, +
-    OrderedListItem(u8), // can't be built > 3 by parsing: 1., 1)
+    Header(u8), // never 0, and <= MAX_HEADER_DEPTH
+    ListItem(u8), // can't be built > 3 by parsing: *, -, +
+    OrderedListItem {
+        // can't be built > 3 by parsing: 1., 1)
+        level: u8,
+        index: u32,
+    },
     Code,
     Quote,
 }
@@ -61,7 +65,7 @@ impl<'a> Composite<'a> {
     pub fn is_list_item(&self) -> bool {
         matches!(
             self.style,
-            CompositeStyle::ListItem(_) | CompositeStyle::OrderedListItem(_)
+            CompositeStyle::ListItem(_) | CompositeStyle::OrderedListItem { .. }
         )
     }
     pub fn is_quote(&self) -> bool {

--- a/src/markdown/line.rs
+++ b/src/markdown/line.rs
@@ -65,6 +65,15 @@ impl<'a> Line<'a> {
             compounds,
         })
     }
+    pub fn new_ordered_list_item(
+        depth: u8,
+        compounds: Vec<Compound<'_>>,
+    ) -> Line<'_> {
+        Line::Normal(Composite {
+            style: CompositeStyle::OrderedListItem(depth),
+            compounds,
+        })
+    }
     pub fn new_header(
         level: u8,
         compounds: Vec<Compound<'_>>,

--- a/src/markdown/line.rs
+++ b/src/markdown/line.rs
@@ -66,11 +66,12 @@ impl<'a> Line<'a> {
         })
     }
     pub fn new_ordered_list_item(
-        depth: u8,
+        level: u8,
+        index: u32,
         compounds: Vec<Compound<'_>>,
     ) -> Line<'_> {
         Line::Normal(Composite {
-            style: CompositeStyle::OrderedListItem(depth),
+            style: CompositeStyle::OrderedListItem { level, index },
             compounds,
         })
     }

--- a/src/parser/line_parser.rs
+++ b/src/parser/line_parser.rs
@@ -186,18 +186,15 @@ impl<'s> LineParser<'s> {
         let mut cells = Vec::new();
         while self.idx < self.src.len() {
             self.idx += 1;
-            let style = if self.src[self.idx..].starts_with("* ") {
-                self.idx += 2;
-                CompositeStyle::ListItem(0)
-            } else if self.src[self.idx..].starts_with(" * ") {
-                self.idx += 3;
-                CompositeStyle::ListItem(1)
-            } else if self.src[self.idx..].starts_with("  * ") {
-                self.idx += 4;
-                CompositeStyle::ListItem(2)
-            } else if self.src[self.idx..].starts_with("   * ") {
-                self.idx += 5;
-                CompositeStyle::ListItem(3)
+            let style = if let Some((depth, consumed, is_ordered)) =
+                list_item_prefix(&self.src[self.idx..])
+            {
+                self.idx += consumed;
+                if is_ordered {
+                    CompositeStyle::OrderedListItem(depth)
+                } else {
+                    CompositeStyle::ListItem(depth)
+                }
             } else if self.src[self.idx..].starts_with("> ") {
                 self.idx += 2;
                 CompositeStyle::Quote
@@ -253,21 +250,14 @@ impl<'s> LineParser<'s> {
         if self.src.starts_with('\t') {
             return Line::new_code(self.code_block_compound_from_idx(1));
         }
-        if self.src.starts_with("* ") {
-            self.idx = 2;
-            return Line::new_list_item(0, self.parse_compounds(false));
-        }
-        if self.src.starts_with(" * ") {
-            self.idx = 3;
-            return Line::new_list_item(1, self.parse_compounds(false));
-        }
-        if self.src.starts_with("  * ") {
-            self.idx = 4;
-            return Line::new_list_item(2, self.parse_compounds(false));
-        }
-        if self.src.starts_with("   * ") {
-            self.idx = 5;
-            return Line::new_list_item(3, self.parse_compounds(false));
+        if let Some((depth, consumed, is_ordered)) = list_item_prefix(self.src) {
+            self.idx = consumed;
+            let compounds = self.parse_compounds(false);
+            return if is_ordered {
+                Line::new_ordered_list_item(depth, compounds)
+            } else {
+                Line::new_list_item(depth, compounds)
+            };
         }
         if self.src == ">" {
             return Line::new_quote(Vec::new());
@@ -310,6 +300,46 @@ fn compounds_are_rule(compounds: &[Compound<'_>]) -> bool {
         }
     }
     true
+}
+
+/// If the line starts with a list item marker (0-3 leading spaces followed by
+/// `* `, `- `, `+ `, or `<digits>. `/`<digits>) `), return the depth, the
+/// number of bytes consumed by the whole prefix, and whether it is an ordered
+/// marker.
+fn list_item_prefix(s: &str) -> Option<(u8, usize, bool)> {
+    let bytes = s.as_bytes();
+    let mut depth = 0;
+    while depth < bytes.len() && bytes[depth] == b' ' {
+        depth += 1;
+    }
+    if depth >= 4 {
+        return None;
+    }
+    let rest = &s[depth..];
+
+    // unordered
+    if rest.starts_with("* ") || rest.starts_with("- ") || rest.starts_with("+ ") {
+        return Some((depth as u8, depth + 2, false));
+    }
+
+    // ordered
+    let mut i = 0;
+    while i < rest.len() && rest.as_bytes()[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == 0 {
+        return None;
+    }
+    if matches!(rest.as_bytes().get(i), Some(b'.') | Some(b')')) {
+        if i + 1 == rest.len() {
+            return Some((depth as u8, depth + i + 1, true));
+        }
+        if rest.as_bytes()[i + 1] == b' ' {
+            return Some((depth as u8, depth + i + 2, true));
+        }
+    }
+
+    None
 }
 
 /// Tests of line parsing
@@ -533,6 +563,47 @@ mod tests {
         assert_eq!(
             Line::from("    * but not this one..."),
             Line::new_code(Compound::raw_str("* but not this one...")),
+        );
+    }
+
+    #[test]
+    fn dash_and_plus_items() {
+        assert_eq!(
+            Line::from("- dash item"),
+            Line::new_list_item(0, vec![Compound::raw_str("dash item"),])
+        );
+        assert_eq!(
+            Line::from(" + plus item"),
+            Line::new_list_item(1, vec![Compound::raw_str("plus item"),])
+        );
+        assert_eq!(
+            Line::from("  - deeper dash"),
+            Line::new_list_item(2, vec![Compound::raw_str("deeper dash"),])
+        );
+        // line starting with "-" but not a marker stays a paragraph
+        assert_eq!(
+            Line::from("-not a list item"),
+            Line::new_paragraph(vec![Compound::raw_str("-not a list item"),])
+        );
+    }
+
+    #[test]
+    fn ordered_items() {
+        assert_eq!(
+            Line::from("1. ordered item"),
+            Line::new_ordered_list_item(0, vec![Compound::raw_str("ordered item"),])
+        );
+        assert_eq!(
+            Line::from("  2) ordered item"),
+            Line::new_ordered_list_item(2, vec![Compound::raw_str("ordered item"),])
+        );
+        assert_eq!(
+            Line::from("42. ordered item"),
+            Line::new_ordered_list_item(0, vec![Compound::raw_str("ordered item"),])
+        );
+        assert_eq!(
+            Line::from("1.5 not an item"),
+            Line::new_paragraph(vec![Compound::raw_str("1.5 not an item"),])
         );
     }
 

--- a/src/parser/line_parser.rs
+++ b/src/parser/line_parser.rs
@@ -186,12 +186,12 @@ impl<'s> LineParser<'s> {
         let mut cells = Vec::new();
         while self.idx < self.src.len() {
             self.idx += 1;
-            let style = if let Some((depth, consumed, is_ordered)) =
+            let style = if let Some((depth, consumed, ordered_index)) =
                 list_item_prefix(&self.src[self.idx..])
             {
                 self.idx += consumed;
-                if is_ordered {
-                    CompositeStyle::OrderedListItem(depth)
+                if let Some(index) = ordered_index {
+                    CompositeStyle::OrderedListItem { level: depth, index }
                 } else {
                     CompositeStyle::ListItem(depth)
                 }
@@ -250,11 +250,11 @@ impl<'s> LineParser<'s> {
         if self.src.starts_with('\t') {
             return Line::new_code(self.code_block_compound_from_idx(1));
         }
-        if let Some((depth, consumed, is_ordered)) = list_item_prefix(self.src) {
+        if let Some((depth, consumed, ordered_index)) = list_item_prefix(self.src) {
             self.idx = consumed;
             let compounds = self.parse_compounds(false);
-            return if is_ordered {
-                Line::new_ordered_list_item(depth, compounds)
+            return if let Some(index) = ordered_index {
+                Line::new_ordered_list_item(depth, index, compounds)
             } else {
                 Line::new_list_item(depth, compounds)
             };
@@ -304,9 +304,9 @@ fn compounds_are_rule(compounds: &[Compound<'_>]) -> bool {
 
 /// If the line starts with a list item marker (0-3 leading spaces followed by
 /// `* `, `- `, `+ `, or `<digits>. `/`<digits>) `), return the depth, the
-/// number of bytes consumed by the whole prefix, and whether it is an ordered
-/// marker.
-fn list_item_prefix(s: &str) -> Option<(u8, usize, bool)> {
+/// number of bytes consumed by the whole prefix, and, for ordered markers,
+/// the index read from the source.
+fn list_item_prefix(s: &str) -> Option<(u8, usize, Option<u32>)> {
     let bytes = s.as_bytes();
     let mut depth = 0;
     while depth < bytes.len() && bytes[depth] == b' ' {
@@ -319,7 +319,7 @@ fn list_item_prefix(s: &str) -> Option<(u8, usize, bool)> {
 
     // unordered
     if rest.starts_with("* ") || rest.starts_with("- ") || rest.starts_with("+ ") {
-        return Some((depth as u8, depth + 2, false));
+        return Some((depth as u8, depth + 2, None));
     }
 
     // ordered
@@ -331,11 +331,12 @@ fn list_item_prefix(s: &str) -> Option<(u8, usize, bool)> {
         return None;
     }
     if matches!(rest.as_bytes().get(i), Some(b'.') | Some(b')')) {
+        let index = rest[..i].parse().unwrap_or(1);
         if i + 1 == rest.len() {
-            return Some((depth as u8, depth + i + 1, true));
+            return Some((depth as u8, depth + i + 1, Some(index)));
         }
         if rest.as_bytes()[i + 1] == b' ' {
-            return Some((depth as u8, depth + i + 2, true));
+            return Some((depth as u8, depth + i + 2, Some(index)));
         }
     }
 
@@ -591,15 +592,15 @@ mod tests {
     fn ordered_items() {
         assert_eq!(
             Line::from("1. ordered item"),
-            Line::new_ordered_list_item(0, vec![Compound::raw_str("ordered item"),])
+            Line::new_ordered_list_item(0, 1, vec![Compound::raw_str("ordered item"),])
         );
         assert_eq!(
             Line::from("  2) ordered item"),
-            Line::new_ordered_list_item(2, vec![Compound::raw_str("ordered item"),])
+            Line::new_ordered_list_item(2, 2, vec![Compound::raw_str("ordered item"),])
         );
         assert_eq!(
             Line::from("42. ordered item"),
-            Line::new_ordered_list_item(0, vec![Compound::raw_str("ordered item"),])
+            Line::new_ordered_list_item(0, 42, vec![Compound::raw_str("ordered item"),])
         );
         assert_eq!(
             Line::from("1.5 not an item"),

--- a/src/parser/text_parser.rs
+++ b/src/parser/text_parser.rs
@@ -66,5 +66,102 @@ where
             }
         }
     }
+    fix_ordered_indexes(&mut lines);
     Text { lines }
+}
+
+/// Renumber the indexes of consecutive OrderedListItem lines so that ordered
+/// lists read as a text have consistent numbering, starting from the index of
+/// the first item in each run.
+fn fix_ordered_indexes(lines: &mut Vec<Line<'_>>) {
+    #[derive(Default)]
+    struct Seq {
+        start: u32,
+        count: u32,
+        active: bool,
+    }
+    let mut seqs: Vec<Seq> = Vec::new();
+    for line in lines.iter_mut() {
+        if let Line::Normal(Composite {
+            style: CompositeStyle::OrderedListItem { level, index },
+            ..
+        }) = line
+        {
+            let level = *level as usize;
+            while seqs.len() <= level {
+                seqs.push(Seq::default());
+            }
+            if seqs[level].active {
+                seqs[level].count += 1;
+            } else {
+                seqs[level].start = *index;
+                seqs[level].count = 1;
+                seqs[level].active = true;
+                // deeper sequences are no longer part of the current run
+                for s in seqs.iter_mut().skip(level + 1) {
+                    s.active = false;
+                }
+            }
+            *index = seqs[level].start + seqs[level].count - 1;
+        } else {
+            for s in seqs.iter_mut() {
+                s.active = false;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+
+    fn assert_ordered(line: &Line, level: u8, index: u32) {
+        match line {
+            Line::Normal(Composite {
+                style: CompositeStyle::OrderedListItem { level: l, index: i },
+                ..
+            }) => {
+                assert_eq!(*l, level);
+                assert_eq!(*i, index);
+            }
+            _ => panic!("expected ordered list item, got {:?}", line),
+        }
+    }
+
+    #[test]
+    fn renumbers_repeated_one_markers() {
+        let text = parse_text("1. a\n1. b\n1. c", Options::default());
+        assert_eq!(text.lines.len(), 3);
+        assert_ordered(&text.lines[0], 0, 1);
+        assert_ordered(&text.lines[1], 0, 2);
+        assert_ordered(&text.lines[2], 0, 3);
+    }
+
+    #[test]
+    fn keeps_ascending_start_indexes() {
+        let text = parse_text("2. a\n3. b\n4. c", Options::default());
+        assert_eq!(text.lines.len(), 3);
+        assert_ordered(&text.lines[0], 0, 2);
+        assert_ordered(&text.lines[1], 0, 3);
+        assert_ordered(&text.lines[2], 0, 4);
+    }
+
+    #[test]
+    fn resets_ordered_index_after_break() {
+        let text = parse_text("1. a\n1. b\n\n1. c", Options::default());
+        assert_eq!(text.lines.len(), 4);
+        assert_ordered(&text.lines[0], 0, 1);
+        assert_ordered(&text.lines[1], 0, 2);
+        assert_ordered(&text.lines[3], 0, 1);
+    }
+
+    #[test]
+    fn handles_nested_ordered_lists() {
+        let text = parse_text("1. a\n 1. inner\n 2. inner\n2. b", Options::default());
+        assert_eq!(text.lines.len(), 4);
+        assert_ordered(&text.lines[0], 0, 1);
+        assert_ordered(&text.lines[1], 1, 1);
+        assert_ordered(&text.lines[2], 1, 2);
+        assert_ordered(&text.lines[3], 0, 2);
+    }
 }


### PR DESCRIPTION
This adds OrderedListItem to CompositeStyle and extends the line parser to recognise:
- unordered `*` / `-` / `+` markers
- ordered `<digits>.` / `<digits>)` markers (with up to 3 leading spaces for nesting)

The source markers are stripped and the text is parsed as normal, so existing formatting still applies. This is the minimad piece needed for [Canop/termimad#75](https://github.com/Canop/termimad/issues/75), where wrapped `-` and `1.` lines were parsed as ordinary paragraphs and got no hanging indent.

I did not change the rendering side here; that lives in termimad.

Co-Authored-By: Claude <noreply@anthropic.com>